### PR TITLE
http.Serve的ListenAndServe以及ListenAndServeTLS方法的描述

### DIFF
--- a/pkg/net_http.htm
+++ b/pkg/net_http.htm
@@ -928,7 +928,7 @@ mux.HandleFunc(&#34;/&#34;, func(w http.ResponseWriter, req *http.Request) {
     <p>Serve会接手监听器l收到的每一个连接，并为每一个连接创建一个新的服务go程。该go程会读取请求，然后调用srv.Handler回复请求。</p>
     <h4 id="Server.ListenAndServe">func (*Server) <a title="View Source" href="https://github.com/golang/go/blob/master/src/net/http/server.go?name=release#1679">ListenAndServe</a> <a class="permalink" href="#pkg-index">&para;</a></h4>
     <pre class="funcdecl">func (srv *<a href="#Server">Server</a>) ListenAndServe() <a href="http://godoc.org/builtin#error">error</a></pre>
-    <p>ListenAndServe监听srv.Addr指定的TCP地址，并且会调用Serve方法接收到的连接。如果srv.Addr为空字符串，会使用":http"。</p>
+    <p>ListenAndServe监听srv.Addr指定的TCP地址，并且会调用Serve方法处理接收到的连接。如果srv.Addr为空字符串，会使用":http"。</p>
     <h4 id="Server.ListenAndServeTLS">func (*Server) <a title="View Source" href="https://github.com/golang/go/blob/master/src/net/http/server.go?name=release#1823">ListenAndServeTLS</a> <a class="permalink" href="#pkg-index">&para;</a></h4>
     <pre class="funcdecl">func (srv *<a href="#Server">Server</a>) ListenAndServeTLS(certFile, keyFile <a href="http://godoc.org/builtin#string">string</a>) <a href="http://godoc.org/builtin#error">error</a></pre>
     <p>ListenAndServeTLS监听srv.Addr确定的TCP地址，并且会调用Serve方法处理接收到的连接。必须提供证书文件和对应的私钥文件。如果证书是由权威机构签发的，certFile参数必须是顺序串联的服务端证书和CA证书。如果srv.Addr为空字符串，会使用":https"。</p>

--- a/pkg/net_http.htm
+++ b/pkg/net_http.htm
@@ -928,10 +928,10 @@ mux.HandleFunc(&#34;/&#34;, func(w http.ResponseWriter, req *http.Request) {
     <p>Serve会接手监听器l收到的每一个连接，并为每一个连接创建一个新的服务go程。该go程会读取请求，然后调用srv.Handler回复请求。</p>
     <h4 id="Server.ListenAndServe">func (*Server) <a title="View Source" href="https://github.com/golang/go/blob/master/src/net/http/server.go?name=release#1679">ListenAndServe</a> <a class="permalink" href="#pkg-index">&para;</a></h4>
     <pre class="funcdecl">func (srv *<a href="#Server">Server</a>) ListenAndServe() <a href="http://godoc.org/builtin#error">error</a></pre>
-    <p>ListenAndServe监听srv.Addr指定的TCP地址，并且会调用Serve方法处理接收到的连接。如果srv.Addr为空字符串，会使用":http"。</p>
+    <p>ListenAndServe监听srv.Addr指定的TCP地址，并且会调用Serve方法处理接收到的连接。如果srv.Addr为空字符串，会使用":http"，ListenAndServe的返回值始终是一个非nil的error，在它宕机或者关闭的时候，会返回一个服务关闭错误(ErrSeverClosed)</p>
     <h4 id="Server.ListenAndServeTLS">func (*Server) <a title="View Source" href="https://github.com/golang/go/blob/master/src/net/http/server.go?name=release#1823">ListenAndServeTLS</a> <a class="permalink" href="#pkg-index">&para;</a></h4>
     <pre class="funcdecl">func (srv *<a href="#Server">Server</a>) ListenAndServeTLS(certFile, keyFile <a href="http://godoc.org/builtin#string">string</a>) <a href="http://godoc.org/builtin#error">error</a></pre>
-    <p>ListenAndServeTLS监听srv.Addr确定的TCP地址，并且会调用Serve方法处理接收到的连接。必须提供证书文件和对应的私钥文件。如果证书是由权威机构签发的，certFile参数必须是顺序串联的服务端证书和CA证书。如果srv.Addr为空字符串，会使用":https"。</p>
+    <p>ListenAndServeTLS监听srv.Addr确定的TCP地址，并且会调用Serve方法处理接收到的连接。必须提供证书文件和对应的私钥文件。如果证书是由权威机构签发的，certFile参数必须是顺序串联的服务端证书和CA证书。如果srv.Addr为空字符串，会使用":https"，ListenAndServe的返回值始终是一个非nil的error，在它宕机或者关闭的时候，会返回一个服务关闭错误(ErrSeverClosed)</p>
     <h3 id="File">type <a title="View Source" href="https://github.com/golang/go/blob/master/src/net/http/fs.go?name=release#58">File</a> <a class="permalink" href="#pkg-index">&para;</a></h3>
     <pre>type File interface {
     <a href="http://godoc.org/io">io</a>.<a href="http://godoc.org/io#Closer">Closer</a>


### PR DESCRIPTION
这里应该是有一个笔误，后面不知道是不是官方包之后增加的描述，在官方标准库的描述里面要多一句就补上来了：
ListenAndServe always returns a non-nil error. After Shutdown or Close, the returned error is ErrServerClosed.